### PR TITLE
Fix form field crash when redisplaying None values

### DIFF
--- a/tests/test_form_field.py
+++ b/tests/test_form_field.py
@@ -98,6 +98,21 @@ class JSONFieldTest(SimpleTestCase):
         form = JSONForm({"json_field": '["bar"]'}, initial={"json_field": ["foo"]})
         self.assertIn("[&quot;foo&quot;]</textarea>", form.as_p())
 
+    def test_redisplay_none_input(self):
+        class JSONForm(Form):
+            json_field = JSONField(required=True)
+
+        tests = [
+            {},
+            {"json_field": None},
+        ]
+        for data in tests:
+            with self.subTest(data=data):
+                form = JSONForm(data)
+                self.assertEqual(form["json_field"].value(), "null")
+                self.assertIn("null</textarea>", form.as_p())
+                self.assertEqual(form.errors["json_field"], ["This field is required."])
+
     def test_redisplay_wrong_input(self):
         """
         Displaying a bound form (typically due to invalid input). The form


### PR DESCRIPTION
Fixes #32.

Backport of https://github.com/django/django/pull/14558.