### PR TITLE
Fix DatabaseFeatures issue for management commands and shell

### DIFF
--- a/src/django_jsonfield_backport/apps.py
+++ b/src/django_jsonfield_backport/apps.py
@@ -16,6 +16,7 @@ class JSONFieldConfig(AppConfig):
     def ready(self):
         if django.VERSION >= (3, 1):
             return
+        features.extend_default_connection()
         features.connect_signal_receivers()
         forms.patch_admin()
         models.register_lookups()

--- a/src/django_jsonfield_backport/apps.py
+++ b/src/django_jsonfield_backport/apps.py
@@ -1,7 +1,7 @@
-import django
+from django import VERSION as django_version
 from django.apps import AppConfig
 
-if django.VERSION >= (3, 0):
+if django_version >= (3, 0):
     from django.utils.translation import gettext_lazy as _
 else:
     from django.utils.translation import ugettext_lazy as _
@@ -14,7 +14,7 @@ class JSONFieldConfig(AppConfig):
     verbose_name = _("JSONField backport from Django 3.1")
 
     def ready(self):
-        if django.VERSION >= (3, 1):
+        if django_version >= (3, 1):
             return
         features.extend_default_connection()
         features.connect_signal_receivers()

--- a/src/django_jsonfield_backport/features.py
+++ b/src/django_jsonfield_backport/features.py
@@ -1,4 +1,4 @@
-from django.db import transaction
+from django.db import connection, transaction
 from django.db.backends.base.features import BaseDatabaseFeatures
 from django.db.backends.signals import connection_created
 from django.db.utils import OperationalError
@@ -70,6 +70,14 @@ def extend_features(connection, **kwargs):
         if callable(feature):
             value = feature(connection.features)
         setattr(connection.features, name, value)
+
+
+def extend_default_connection():
+    # For management commands and shell, another app may have already created
+    # a default database connection before the signal receiver is connected,
+    # so we extend_features immediately if the connection exists and is usable.
+    if connection.connection and connection.is_usable():
+        extend_features(connection)
 
 
 def connect_signal_receivers():

--- a/src/django_jsonfield_backport/forms.py
+++ b/src/django_jsonfield_backport/forms.py
@@ -44,7 +44,6 @@ if django.VERSION >= (3, 1):
             except json.JSONDecodeError:
                 return builtin_fields.InvalidJSONInput(data)
 
-
 else:
 
     class JSONField(CharField):

--- a/src/django_jsonfield_backport/models.py
+++ b/src/django_jsonfield_backport/models.py
@@ -1,7 +1,7 @@
 import json
 import warnings
 
-import django
+from django import VERSION as django_version
 from django.core import checks, exceptions
 from django.db import NotSupportedError, connections, router
 from django.db.models import lookups
@@ -42,7 +42,7 @@ class CheckFieldDefaultMixin:
         return errors
 
 
-if django.VERSION >= (3, 1):
+if django_version >= (3, 1):
     from django.db.models import JSONField as BuiltinJSONField
 
     class JSONField(BuiltinJSONField):
@@ -344,7 +344,7 @@ class JSONExact(lookups.Exact):
         return rhs, rhs_params
 
 
-if django.VERSION >= (3, 1):
+if django_version >= (3, 1):
     from django.db.models.fields.json import (
         KeyTextTransform as BuiltinKeyTextTransform,
         KeyTransform as BuiltinKeyTransform,

--- a/src/django_jsonfield_backport/models.py
+++ b/src/django_jsonfield_backport/models.py
@@ -52,7 +52,6 @@ if django.VERSION >= (3, 1):
             "id": "django_jsonfield_backport.W001",
         }
 
-
 else:
 
     class JSONField(CheckFieldDefaultMixin, Field):
@@ -370,7 +369,6 @@ if django.VERSION >= (3, 1):
                 stacklevel=2,
             )
             super().__init__(*args, **kwargs)
-
 
 else:
 

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -1,6 +1,6 @@
 from unittest import skipUnless
 
-import django
+from django import VERSION as django_version
 from django.core.checks import Warning as DjangoWarning
 from django.test import SimpleTestCase
 
@@ -9,7 +9,7 @@ from django_jsonfield_backport import forms, models
 from .models import JSONModel
 
 
-@skipUnless(django.VERSION >= (3, 1), "Only show deprecation message for Django >= 3.1.")
+@skipUnless(django_version >= (3, 1), "Only show deprecation message for Django >= 3.1.")
 class DeprecationTests(SimpleTestCase):
     def test_model_field_deprecation_message(self):
         self.assertEqual(

--- a/tests/test_extend_features.py
+++ b/tests/test_extend_features.py
@@ -1,9 +1,11 @@
-from unittest import mock
+from unittest import mock, skipIf
 
+import django
+from django.db import connection
 from django.db.backends.base.features import BaseDatabaseFeatures
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
-from django_jsonfield_backport.features import extend_features
+from django_jsonfield_backport.features import extend_default_connection, extend_features
 
 FIELD_NAME = "this_field_should_never_exist"
 
@@ -82,3 +84,14 @@ class ExtendFeaturesTest(SimpleTestCase):
 
         # Make sure the fake feature is still not there
         self.assertIs(hasattr(connection.features, FIELD_NAME), False)
+
+
+@skipIf(django.VERSION >= (3, 1), "Not applicable.")
+class ExtendDefaultConnectionTest(TestCase):
+    def setUp(self):
+        connection.features = connection.features_class(connection)
+
+    def test_extend_default_connection(self):
+        self.assertIs(hasattr(connection.features, "supports_json_field"), False)
+        extend_default_connection()
+        self.assertIs(hasattr(connection.features, "supports_json_field"), True)

--- a/tests/test_extend_features.py
+++ b/tests/test_extend_features.py
@@ -1,6 +1,6 @@
 from unittest import mock, skipIf
 
-import django
+from django import VERSION as django_version
 from django.db import connection
 from django.db.backends.base.features import BaseDatabaseFeatures
 from django.test import SimpleTestCase, TestCase
@@ -86,7 +86,7 @@ class ExtendFeaturesTest(SimpleTestCase):
         self.assertIs(hasattr(connection.features, FIELD_NAME), False)
 
 
-@skipIf(django.VERSION >= (3, 1), "Not applicable.")
+@skipIf(django_version >= (3, 1), "Not applicable.")
 class ExtendDefaultConnectionTest(TestCase):
     def setUp(self):
         connection.features = connection.features_class(connection)

--- a/tests/test_invalid_models.py
+++ b/tests/test_invalid_models.py
@@ -1,6 +1,6 @@
 from unittest import skipIf
 
-import django
+from django import VERSION as django_version
 from django.core.checks import Error, Warning as DjangoWarning
 from django.db import connection, models
 from django.test import TestCase, skipUnlessDBFeature
@@ -10,7 +10,7 @@ from django_jsonfield_backport.models import JSONField
 
 
 @isolate_apps("tests")
-@skipIf(django.VERSION >= (3, 1), "Not applicable.")
+@skipIf(django_version >= (3, 1), "Not applicable.")
 class CheckTests(TestCase):
     @skipUnlessDBFeature("supports_json_field")
     def test_ordering_pointing_to_json_field_value(self):
@@ -53,7 +53,7 @@ class CheckTests(TestCase):
 
 @isolate_apps("tests")
 @skipUnlessDBFeature("supports_json_field")
-@skipIf(django.VERSION >= (3, 1), "Not applicable.")
+@skipIf(django_version >= (3, 1), "Not applicable.")
 class DefaultTests(TestCase):
     def test_invalid_default(self):
         class Model(models.Model):

--- a/tests/test_model_field.py
+++ b/tests/test_model_field.py
@@ -2,7 +2,7 @@ import operator
 import uuid
 from unittest import mock, skipIf
 
-import django
+from django import VERSION as django_version
 from django.core import serializers
 from django.core.exceptions import ValidationError
 from django.core.serializers.json import DjangoJSONEncoder
@@ -63,7 +63,7 @@ class TestMethods(SimpleTestCase):
         self.assertEqual(kwargs["encoder"], DjangoJSONEncoder)
         self.assertEqual(kwargs["decoder"], CustomJSONDecoder)
 
-    @skipIf(django.VERSION >= (3, 1), "Not applicable.")
+    @skipIf(django_version >= (3, 1), "Not applicable.")
     def test_get_transforms(self):
         @JSONField.register_lookup
         class MyTransform(Transform):
@@ -109,7 +109,7 @@ class TestValidation(SimpleTestCase):
 
 
 class TestFormField(SimpleTestCase):
-    @skipIf(django.VERSION >= (3, 1), "Not applicable.")
+    @skipIf(django_version >= (3, 1), "Not applicable.")
     def test_formfield(self):
         model_field = JSONField()
         form_field = model_field.formfield()

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,8 @@ DB_BACKEND =
 deps =
     coverage
     coveralls
+    # Prevent upgrading distutils to a version that deprecates LooseVersion used by Django
+    setuptools<=59.5.0
     django22: Django~=2.2.0
     django30: Django~=3.0.0
     django31: Django~=3.1.0


### PR DESCRIPTION
While it works in production and with runserver, JSONFieldConfig.ready() is getting called after the connection_created signal has been sent while running a management command or a shell. So, extend_features() never gets called.

To solve this, we check to see if the connection is_usable and extend_features immediately if it is. If not, register with the connection_created signal and wait until that is sent.

I wasn't sure if the right place to put this was in the ready() method or in connect_signal_receivers(), so I picked one. I'd be happy to put it somewhere else.